### PR TITLE
Add support for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
     - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
+    - env: CONFIG=linux_aarch64_ UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
 
 script:
   - export CI=travis

--- a/recipe/aarch64.patch
+++ b/recipe/aarch64.patch
@@ -1,0 +1,21 @@
+diff -ur a/config.sub b/config.sub
+--- config.sub.orig        2020-06-24 13:43:03.800099937 +0000
++++ config.sub        2020-06-24 13:42:07.847550335 +0000
+@@ -248,7 +248,7 @@
+        | alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
+        | alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+        | am33_2.0 \
+-       | arc | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
++       | arc | arm | aarch64* | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
+        | bfin \
+        | c4x | clipper \
+        | d10v | d30v | dlx | dsp16xx \
+@@ -330,7 +330,7 @@
+        | alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+        | alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+        | alphapca5[67]-* | alpha64pca5[67]-* | arc-* \
+-       | arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++       | arm-*  | aarch64*| armbe-* | armle-* | armeb-* | armv*-* \
+        | avr-* | avr32-* \
+        | bfin-* | bs2000-* \
+        | c[123]* | c30-* | [cjt]90-* | c4x-* | c54x-* | c55x-* | c6x-* \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+if [ $(uname -m) = 'aarch64' ]
+then
+./configure --prefix=$PREFIX --host=aarch64-linux-gnu --build=aarch64-linux-gnu
+else
 ./configure --prefix=$PREFIX --host=$HOST --build=$BUILD
+fi
 
 make -j$CPU_COUNT
 make check -j$CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     - makefile.vc.patch  # [win]
     - nmake.opt.patch  # [win]
     - freexl.c.patch  # [win]
+    - aarch64.patch
 
 build:
   number: 1002
@@ -22,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - libiconv  # [win]
+    - make
 
 test:
   commands:


### PR DESCRIPTION
Add support to build freexl-feedstock on aarch64.

- Add aarch64 build in travis CI
- Add aarch64.patch to provide aarch64 support in freexl package